### PR TITLE
margin botom et taille cards réduite

### DIFF
--- a/app/assets/stylesheets/components/_places-card.scss
+++ b/app/assets/stylesheets/components/_places-card.scss
@@ -1,6 +1,6 @@
 .places-card {
-  width: 300px;
-  height :280px;
+  width: 280px;
+  height :260px;
   overflow: hidden;
   background: white;
   box-shadow: 0 0 15px rgba(0,0,0,0.2);

--- a/app/assets/stylesheets/components/_places-cards.scss
+++ b/app/assets/stylesheets/components/_places-cards.scss
@@ -4,6 +4,7 @@
   flex-grow: 1;
   grid-gap: 12px;
   padding: 15px 10px;
+  padding-bottom: 120px;
 }
 
 @media (min-width: 100px) and (max-width: 575px) {


### PR DESCRIPTION
Réduction de la margin bottom des cards et changement de largeur pour intégrer les cards et la map sans déborder 
![Capture d’écran 2020-02-19 à 10 42 54](https://user-images.githubusercontent.com/57529666/74821989-bc290180-5304-11ea-9ff0-a38685c8a52f.png)
